### PR TITLE
28 render markup headings

### DIFF
--- a/app/models/diary_entry.rb
+++ b/app/models/diary_entry.rb
@@ -63,7 +63,7 @@ class DiaryEntry < ActiveRecord::Base
     until stack.empty?
       until part.length >= BREAK_AFTER || stack.empty?
         current_component = stack.shift
-        subheading ||= current_component.heading if result.present? # no subheading at the very beginning
+        subheading ||= render(current_component, :heading) if result.present? # no subheading at the very beginning
         part += ' ' if part.present?
         part += render(current_component, :main_part)
 

--- a/features/diary_entries/markup_in_headings.feature
+++ b/features/diary_entries/markup_in_headings.feature
@@ -1,0 +1,87 @@
+@453
+Feature: Render markup in headings
+  As an editor
+  I want to be able to use markup for sensor values as well as events in
+  the headings of text components in order to structure the diary entry
+
+  Background:
+    Given we have these diary entries in our database:
+      | Id | Moment           | release |
+      | 1  | 2017-06-21 14:00 | final   |
+    And a humidity sensor with some sensor readings
+    Given I have two short text commponents, that are active right now:
+      | Heading                                     | Highest priority |
+      | { value(1) }: That’s today’s humidity       | high             |
+      | Let’s repeat it one more time: { value(1) } | low              |
+    But there is also a medium prioritized, active component with a really long text
+
+  Scenario: Render markup on the reports page
+    When I visit the landing page
+    Then I can see the main heading:
+    """
+    50.0 %: That’s today’s humidity
+    """
+    And I can see a subheading:
+    """
+    Let’s repeat it one more time: 50.0 %
+    """
+
+  Scenario: Render markup when requesting JSON via the API
+    Given I send and accept JSON
+    When I send a GET request to "/reports/1/diary_entries/1"
+    Then the JSON response should be:
+    """
+    {
+      "id": 1,
+      "moment": "2017-06-21T14:00:00.000+02:00",
+      "release": "final",
+      "text_components": [
+        {
+          "closing": "MyText",
+          "from_day": null,
+          "heading": "50.0 %: That’s today’s humidity",
+          "id": 1,
+          "image_alt": null,
+          "image_url": "/images/original/missing.png",
+          "image_url_big": "/images/big/missing.png",
+          "image_url_small": "/images/small/missing.png",
+          "introduction": "MyText",
+          "main_part": "MyText",
+          "question_answers": [],
+          "to_day": null,
+          "url": "http://example.org/reports/1/text_components/1.json"
+        },
+        {
+          "closing": "MyText",
+          "from_day": null,
+          "heading": "MyString",
+          "id": 3,
+          "image_alt": null,
+          "image_url": "/images/original/missing.png",
+          "image_url_big": "/images/big/missing.png",
+          "image_url_small": "/images/small/missing.png",
+          "introduction": "MyText",
+          "main_part": "Blaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhhh!",
+          "question_answers": [],
+          "to_day": null,
+          "url": "http://example.org/reports/1/text_components/3.json"
+        },
+        {
+          "closing": "MyText",
+          "from_day": null,
+          "heading": "Let’s repeat it one more time: 50.0 %",
+          "id": 2,
+          "image_alt": null,
+          "image_url": "/images/original/missing.png",
+          "image_url_big": "/images/big/missing.png",
+          "image_url_small": "/images/small/missing.png",
+          "introduction": "MyText",
+          "main_part": "MyText",
+          "question_answers": [],
+          "to_day": null,
+          "url": "http://example.org/reports/1/text_components/2.json"
+        }
+      ],
+      "url": "http://example.org/reports/1/diary_entries/1.json"
+    }
+    """

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1437,6 +1437,21 @@ Given(/^for this diary entry we have an active text component:$/) do |text|
                            triggers: [trigger])
 end
 
+Given(/^for this diary entry we have an active text component with the heading \"(.+)\":$/) do |heading, text|
+  trigger = create(:trigger, report: Report.current)
+  create(:condition,
+         sensor: @humidity_sensor,
+         trigger: trigger,
+         from: 0,
+         to: 100)
+  @text_component = create(:text_component,
+                           report: Report.current,
+                           channels: [Channel.sensorstory],
+                           heading: heading,
+                           main_part: text,
+                           triggers: [trigger])
+end
+
 Given(/^the sensor live report started on "([^"]*)"$/) do |date|
   @report = Report.current
   @report.start_date = date


### PR DESCRIPTION
This PR closes #28. Actually, the story.board already renders markup in headings if you request data via the API. It does not, however, render markup in reports views.

I’ve added a cucumber feature to ensure markup in headings is rendered in report views as well as when requested via the API and implemented the missing behavior for report views.