### PR TITLE
[WIP] 26 accumulate sensor readings when importing

### DIFF
--- a/app/lib/wolf_waagen_api/import.rb
+++ b/app/lib/wolf_waagen_api/import.rb
@@ -91,13 +91,11 @@ module WolfWaagenApi
         value = point.data
         next if value.nil? # some values might be `nil`
 
-        if interval
-          value = accumulated_value(sensor: sensor, interval: interval, point: point)
-        end
-        
+        value = accumulated_value(sensor: sensor, interval: interval, point: point) if interval
+
         # binding.pry if sensor.id == 38
 
-        reading = Sensor::Reading.find_or_create_by(
+        Sensor::Reading.find_or_create_by(
           sensor: sensor,
           created_at: point.datetime,
           calibrated_value: value,

--- a/app/lib/wolf_waagen_api/import.rb
+++ b/app/lib/wolf_waagen_api/import.rb
@@ -6,7 +6,8 @@ module WolfWaagenApi
       property: 'Ertrag (Wolf Waagen API)',
       unit: 'kg',
       accuracy: 2,
-      series_id: 'yield'
+      series_id: 'yield',
+      accumulate: :daily
     }, {
       property: 'Außentemperatur (Wolf Waagen API)',
       unit: '°C',

--- a/app/lib/wolf_waagen_api/import.rb
+++ b/app/lib/wolf_waagen_api/import.rb
@@ -86,12 +86,16 @@ module WolfWaagenApi
 
     def save_series_data(series:, sensor:, interval: nil)
       series.points.each do |point|
+        # binding.pry if sensor.id == 38
+
         value = point.data
-        next unless value # some values might be `nil`
+        next if value.nil? # some values might be `nil`
 
         if interval
           value = accumulated_value(sensor: sensor, interval: interval, point: point)
         end
+        
+        # binding.pry if sensor.id == 38
 
         reading = Sensor::Reading.find_or_create_by(
           sensor: sensor,

--- a/app/lib/wolf_waagen_api/import.rb
+++ b/app/lib/wolf_waagen_api/import.rb
@@ -87,10 +87,13 @@ module WolfWaagenApi
     def save_series_data(series:, sensor:, interval: nil)
       series.points.each do |point|
         value = point.data
+        next unless value # some values might be `nil`
 
-        value = accumulated_value(sensor: sensor, interval: interval, point: point) if interval
+        if interval
+          value = accumulated_value(sensor: sensor, interval: interval, point: point)
+        end
 
-        Sensor::Reading.find_or_create_by(
+        reading = Sensor::Reading.find_or_create_by(
           sensor: sensor,
           created_at: point.datetime,
           calibrated_value: value,
@@ -139,7 +142,7 @@ module WolfWaagenApi
       range = intervals[interval]
       latest_record = sensor.sensor_readings.where(created_at: range).order('created_at').last
       latest_value = latest_record&.calibrated_value || 0
-
+      
       latest_value + value
     end
   end

--- a/app/lib/wolf_waagen_api/import.rb
+++ b/app/lib/wolf_waagen_api/import.rb
@@ -121,7 +121,13 @@ module WolfWaagenApi
 
         # If no readings have been imported yet, fetch readings
         # since the beginning of the report
-        latest_reading_date ||= @report.start_date
+        unless latest_reading_date
+          start_date = @report.start_date
+          # the start date's zimezone is UTC, local timezone
+          # (e. g. Europe/Berlin) is needed
+          start_date = Time.zone.local(start_date.year, start_date.month, start_date.day)
+          latest_reading_date = start_date
+        end
 
         date = latest_reading_date if date.nil? || latest_reading_date < date
       end

--- a/app/lib/wolf_waagen_api/import.rb
+++ b/app/lib/wolf_waagen_api/import.rb
@@ -150,7 +150,7 @@ module WolfWaagenApi
       range = intervals[interval]
       latest_record = sensor.sensor_readings.where(created_at: range).order('created_at').last
       latest_value = latest_record&.calibrated_value || 0
-      
+
       latest_value + value
     end
   end

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe WolfWaagenApi::Import do
 
   describe '#save_data' do
     context 'given a single matching sensor' do
-      subject { wolf_sensor.sensor_readings.pluck(:calibrated_value) }
+      subject { wolf_sensor.sensor_readings.order(:created_at).pluck(:calibrated_value) }
 
       before { wolf_sensor }
 
@@ -188,10 +188,10 @@ RSpec.describe WolfWaagenApi::Import do
 
       it 'creates sensor readings for both sensors' do
         import.save_data(result: result)
-        saved_values1 = wolf_sensor.sensor_readings.pluck(:calibrated_value)
-        saved_values2 = wolf_sensor2.sensor_readings.pluck(:calibrated_value)
+        saved_values1 = wolf_sensor.sensor_readings.order(:created_at).pluck(:calibrated_value)
+        saved_values2 = wolf_sensor2.sensor_readings.order(:created_at).pluck(:calibrated_value)
 
-        expect(saved_values1).to eq([10, 30, 30])
+        expect(saved_values1).to eq([10, 20, 30])
         expect(saved_values2).to eq([10, 20, 30])
       end
     end
@@ -222,8 +222,8 @@ RSpec.describe WolfWaagenApi::Import do
 
       it 'creates readings for sensors of both types' do
         import.save_data(result: result)
-        saved_values1 = sensor1.sensor_readings.pluck(:calibrated_value)
-        saved_values2 = sensor2.sensor_readings.pluck(:calibrated_value)
+        saved_values1 = sensor1.sensor_readings.order(:created_at).pluck(:calibrated_value)
+        saved_values2 = sensor2.sensor_readings.order(:created_at).pluck(:calibrated_value)
 
         expect(saved_values1).to eq([10, 30, 30, 70]) # type for accumulated yield
         expect(saved_values2).to eq([10, 20, 30, 40]) # type for yield data only
@@ -234,7 +234,7 @@ RSpec.describe WolfWaagenApi::Import do
   describe '#save_series_data' do
 
     context 'given an accumulation interval' do
-      subject { wolf_sensor.sensor_readings.pluck(:calibrated_value) }
+      subject { wolf_sensor.sensor_readings.order(:created_at).pluck(:calibrated_value) }
 
       context 'accumulates values' do
         before do

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -9,21 +9,8 @@ RSpec.describe WolfWaagenApi::Import do
     create(:report, hive_id: 'HIVE_ID', start_date: DateTime.new(2019, 1, 1))
   end
 
-  let(:report_without_hive_id) do
-    create(:report, hive_id: nil)
-  end
-
-  let(:other_report) do
-    create(:report, hive_id: 'HIVE_ID2')
-  end
-
   let(:wolf_sensor_type) do
-    specified_type = WolfWaagenApi::Import::SENSOR_TYPES.second
-    create(:sensor_type, property: specified_type[:property], unit: specified_type[:unit])
-  end
-
-  let(:wolf_sensor_type2) do
-    specified_type = WolfWaagenApi::Import::SENSOR_TYPES.second
+    specified_type = WolfWaagenApi::Import::SENSOR_TYPES.third
     create(:sensor_type, property: specified_type[:property], unit: specified_type[:unit])
   end
 
@@ -33,42 +20,6 @@ RSpec.describe WolfWaagenApi::Import do
 
   let(:wolf_sensor2) do
     create(:sensor, sensor_type: wolf_sensor_type, name: 'Wolf Sensor 2', report: report)
-  end
-
-  let(:wolf_sensor3) do
-    create(:sensor, sensor_type: wolf_sensor_type2, name: 'Wolf Sensor 3', report: report)
-  end
-
-  let(:wolf_sensor_reading) do
-    create(
-      :sensor_reading,
-      sensor: wolf_sensor,
-      created_at: DateTime.new(2019, 1, 2),
-      calibrated_value: 100,
-      uncalibrated_value: 100
-    )
-  end
-
-  let(:wolf_sensor_reading2) do
-    create(
-      :sensor_reading,
-      sensor: wolf_sensor2,
-      created_at: DateTime.new(2019, 1, 3),
-      calibrated_value: 100,
-      uncalibrated_value: 100
-    )
-  end
-
-  let(:other_sensor_type) do
-    create(:sensor_type, property: 'Other Sensor Type', unit: '')
-  end
-
-  let(:other_type_sensor) do
-    create(:sensor, sensor_type: other_sensor_type, name: 'Other Sensor', report: report)
-  end
-
-  let(:other_report_sensor) do
-    create(:sensor, sensor_type: wolf_sensor_type, name: 'Other Report’s Wolf Sensor', report: other_report)
   end
 
   let(:import) { described_class.new(report: report) }
@@ -88,21 +39,25 @@ RSpec.describe WolfWaagenApi::Import do
         pointStart: 1546300800000, # 2019-01-01 00:00:00
         pointInterval: 12.hours.in_milliseconds,
         series: [{
-          # temperature (not accumulated)
-          id: WolfWaagenApi::Import::SENSOR_TYPES.second[:series_id],
+          # temperature
+          id: WolfWaagenApi::Import::SENSOR_TYPES.third[:series_id],
           values: [10, 20, 30]
         }, {
-          # yield (accumulated daily)
+          # yield
           id: WolfWaagenApi::Import::SENSOR_TYPES.first[:series_id],
-         # we have a daily accumulation interval and 12 hours frequency for new sensor readings
-         # so below, two values go together
-          values: [10, 20, 30, 40] 
+          # we have a daily accumulation interval and 12 hours frequency for new sensor readings
+          # so below, two values go together
+          values: [10, 20, 30, 40]
         }]
       }
     )
   end
 
   describe '#initialize' do
+    let(:report_without_hive_id) do
+      create(:report, hive_id: nil)
+    end
+
     it 'validates report' do
       expect { described_class.new(report: nil) }.to raise_error ArgumentError
     end
@@ -116,36 +71,62 @@ RSpec.describe WolfWaagenApi::Import do
     subject { import.api_sensors }
 
     context 'given sensors of types not sepcified in constant' do
+      let(:other_type) do
+        create(:sensor_type, property: 'Other Sensor Type', unit: '')
+      end
+
+      let(:other_sensor) do
+        create(:sensor, sensor_type: other_type, name: 'Other Sensor', report: report)
+      end
+
       before do
         wolf_sensor
-        other_type_sensor
+        other_sensor
       end
 
       it { is_expected.to eq([wolf_sensor]) }
     end
 
     context 'given sensor for other reports' do
+      let(:other_report) do
+        create(:report, hive_id: 'HIVE_ID2')
+      end
+
+      let(:other_sensor) do
+        create(:sensor, sensor_type: wolf_sensor_type, name: 'Other Report’s Wolf Sensor', report: other_report)
+      end
+
       before do
         wolf_sensor
-        other_report_sensor
+        other_sensor
       end
 
       it { is_expected.to eq([wolf_sensor]) }
-    end
-
-    context 'given no matching sensor' do
-      before { other_sensor_type }
-
-      it { is_expected.to eq([]) }
-    end
-
-    context 'given no sensor types match' do
-      it { is_expected.to eq([]) }
     end
   end
 
   describe '#start_date' do
     subject { import.start_date }
+
+    let(:wolf_sensor_reading) do
+      create(
+        :sensor_reading,
+        sensor: wolf_sensor,
+        created_at: DateTime.new(2019, 1, 2),
+        calibrated_value: 100,
+        uncalibrated_value: 100
+      )
+    end
+
+    let(:wolf_sensor_reading2) do
+      create(
+        :sensor_reading,
+        sensor: wolf_sensor2,
+        created_at: DateTime.new(2019, 1, 3),
+        calibrated_value: 100,
+        uncalibrated_value: 100
+      )
+    end
 
     context 'given no sensor readings for one of two sensors' do
       before do
@@ -174,13 +155,14 @@ RSpec.describe WolfWaagenApi::Import do
   end
 
   describe '#save_data' do
-
     context 'given a single matching sensor' do
       subject { wolf_sensor.sensor_readings.pluck(:calibrated_value) }
+
       before { wolf_sensor }
 
       context 'creates sensor readings' do
         before { import.save_data(result: result) }
+
         it { is_expected.to eq([10, 20, 30]) }
       end
 
@@ -190,9 +172,8 @@ RSpec.describe WolfWaagenApi::Import do
           import.save_data(result: result)
         end
 
-        it { is_expected.to eq([10, 20, 30] )}
+        it { is_expected.to eq([10, 20, 30]) }
       end
-
     end
 
     context 'given two sensors of the same sensor type' do
@@ -206,31 +187,47 @@ RSpec.describe WolfWaagenApi::Import do
         saved_values1 = wolf_sensor.sensor_readings.pluck(:calibrated_value)
         saved_values2 = wolf_sensor2.sensor_readings.pluck(:calibrated_value)
 
-        expect(saved_values1).to eq([10, 20, 30])
+        expect(saved_values1).to eq([10, 30, 30])
         expect(saved_values2).to eq([10, 20, 30])
       end
     end
 
     context 'given two sensor types for the same series' do
+      let(:sensor_type1) do
+        type = WolfWaagenApi::Import::SENSOR_TYPES.first
+        create(:sensor_type, property: type[:property], unit: type[:unit])
+      end
+
+      let(:sensor_type2) do
+        type = WolfWaagenApi::Import::SENSOR_TYPES.second
+        create(:sensor_type, property: type[:property], unit: type[:unit])
+      end
+
+      let(:sensor1) do
+        create(:sensor, sensor_type: sensor_type1, name: 'Sensor 1', report: report)
+      end
+
+      let(:sensor2) do
+        create(:sensor, sensor_type: sensor_type2, name: 'Sensor 2', report: report)
+      end
+
       before do
-        wolf_sensor
-        wolf_sensor3
+        sensor1
+        sensor2
       end
 
       it 'creates readings for sensors of both types' do
         import.save_data(result: result)
-        saved_values1 = wolf_sensor.sensor_readings.pluck(:calibrated_value)
-        saved_values3 = wolf_sensor3.sensor_readings.pluck(:calibrated_value)
+        saved_values1 = sensor1.sensor_readings.pluck(:calibrated_value)
+        saved_values2 = sensor2.sensor_readings.pluck(:calibrated_value)
 
-        expect(saved_values1).to eq([10, 20, 30])
-        expect(saved_values2).to eq([10, 20, 30])
+        expect(saved_values1).to eq([10, 30, 30, 70])
+        expect(saved_values2).to eq([10, 20, 30, 40])
       end
     end
-
   end
 
   describe '#save_series_data' do
-
     context 'given an accumulation interval' do
       context 'accumulates values' do
         subject { wolf_sensor.sensor_readings.pluck(:calibrated_value) }
@@ -246,7 +243,6 @@ RSpec.describe WolfWaagenApi::Import do
         it { is_expected.to eq([10, 30, 30, 70]) }
       end
     end
-
   end
 
   describe '#accumulated_value' do

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -139,8 +139,9 @@ RSpec.describe WolfWaagenApi::Import do
         wolf_sensor_reading
       end
 
-      it 'returns the report start date' do
-        is_expected.to eq(DateTime.new(2019, 1, 1))
+      it 'returns the report start date with default time zone' do
+        # time zone is Europe/Berlin, which has a one hour offset during winter
+        is_expected.to eq(DateTime.new(2019, 1, 1, 0, 0, 0, '+0100'))
       end
     end
 

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -233,7 +233,6 @@ RSpec.describe WolfWaagenApi::Import do
   end
 
   describe '#save_series_data' do
-
     context 'given an accumulation interval' do
       subject { wolf_sensor.sensor_readings.order(:created_at).pluck(:calibrated_value) }
 
@@ -261,7 +260,6 @@ RSpec.describe WolfWaagenApi::Import do
         it { is_expected.to eq([10, 10, 30]) }
       end
     end
-
   end
 
   describe '#accumulated_value' do

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -85,7 +85,9 @@ RSpec.describe WolfWaagenApi::Import do
         }, {
           # yield (accumulated daily)
           id: WolfWaagenApi::Import::SENSOR_TYPES.first[:series_id],
-          values: [10, 20, 30, 40]
+         # we have a daily accumulation interval and 12 hours frequency for new sensor readings
+         # so below, two values go together
+          values: [10, 20, 30, 40] 
         }]
       }
     )

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe WolfWaagenApi::Import do
       request: request,
       data: {
         pointStart: 1546300800000, # 2019-01-01 00:00:00
-        pointInterval: 1000 * 60 * 60 * 12,
+        pointInterval: 12.hours.in_milliseconds,
         series: [{
           # temperature (not accumulated)
           id: WolfWaagenApi::Import::SENSOR_TYPES.second[:series_id],

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -221,8 +221,8 @@ RSpec.describe WolfWaagenApi::Import do
         saved_values1 = sensor1.sensor_readings.pluck(:calibrated_value)
         saved_values2 = sensor2.sensor_readings.pluck(:calibrated_value)
 
-        expect(saved_values1).to eq([10, 30, 30, 70])
-        expect(saved_values2).to eq([10, 20, 30, 40])
+        expect(saved_values1).to eq([10, 30, 30, 70]) # type for accumulated yield
+        expect(saved_values2).to eq([10, 20, 30, 40]) # type for yield data only
       end
     end
   end

--- a/spec/lib/wolf_waagen_api/import_spec.rb
+++ b/spec/lib/wolf_waagen_api/import_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe WolfWaagenApi::Import do
         }, {
           # yield
           id: WolfWaagenApi::Import::SENSOR_TYPES.first[:series_id],
-          values: [10, nil, nil, 30]
+          values: [10, 0, nil, 30]
         }]
       }
     )
@@ -257,7 +257,7 @@ RSpec.describe WolfWaagenApi::Import do
           )
         end
 
-        it { is_expected.to eq([10, 30]) }
+        it { is_expected.to eq([10, 10, 30]) }
       end
     end
 


### PR DESCRIPTION
This PR closes #26.

This PR allows to set a `:accumulate` option to sensors set in `WolfWaagenApi::Import::SENSOR_TYPES`. If set to either `:daily`, `:monthly`, `:weekly`, `:quarterly`, or `:yearly`, sensor values of the specified interval will be summed up when importing new values. This is handy in case the API returns a change (e. g. how much the yield has grown in the past hour), but editors do want to use total values (e. g. the total yield of the current day) in the story.board.